### PR TITLE
Fix: change returning value when stack is empty

### DIFF
--- a/lib/validate/index.js
+++ b/lib/validate/index.js
@@ -57,7 +57,10 @@ var dfs = function(rule, tgt, stack) {
 var fetch = function(tgt, stack) {
 	var i;
 
-	if (stack.length === 0) return;
+	if (stack.length === 0) {
+		if ( tgt == undefined ) return;
+		return tgt;
+	}
 
 	for (i = 0; i < stack.length - 1; i++) {
 		tgt = tgt[stack[i]];


### PR DESCRIPTION
validator에서 stack이 비어있는 경우(i.e. object 가 아닌 값들에 대한 validation 시도) fetch를 불렀을 때 언제나 undefined를 return 하는 것을 수정하였습니다.

